### PR TITLE
Potential fix for code scanning alert no. 2: Replacement of a substring with itself

### DIFF
--- a/src/core/automator/index.ts
+++ b/src/core/automator/index.ts
@@ -7,7 +7,7 @@ import { format } from '@/utils/format';
 export function formatResult(result: any): string {
 	if (result instanceof Decimal) return format(result);
 	else if (typeof result == 'string') {
-		return `"${result.replace(/\\/g, '\\\\').replace(/"/g, '\"')}"`;
+		return `"${result.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 	} else if (Array.isArray(result)) {
 		return `[${result.map((x) => formatResult(x)).join(',')}]`;
 	} else if (result === undefined) return `No result`;

--- a/src/core/automator/index.ts
+++ b/src/core/automator/index.ts
@@ -7,7 +7,7 @@ import { format } from '@/utils/format';
 export function formatResult(result: any): string {
 	if (result instanceof Decimal) return format(result);
 	else if (typeof result == 'string') {
-		return `"${result.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+		return `"${result.replace(/\\/g, '\\\\').replace(/"/g, '"')}"`;
 	} else if (Array.isArray(result)) {
 		return `[${result.map((x) => formatResult(x)).join(',')}]`;
 	} else if (result === undefined) return `No result`;


### PR DESCRIPTION
Potential fix for [https://github.com/RBN-rewrite-team/RBNR/security/code-scanning/2](https://github.com/RBN-rewrite-team/RBNR/security/code-scanning/2)

To fix the problem:
- Change the replacement string for double quotes from `'\"'` to `'\\"'`. In JavaScript/TypeScript, a replacement of `'\\"'` means the resulting string will have an actual backslash followed by a double quote (`\"`), properly escaping double quotes in the output string.
- Only line 10 in `src/core/automator/index.ts` is affected.
- No imports or other definitions are needed; just a correction of the replacement string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
