### PR TITLE
Potential fix for code scanning alert no. 3: Replacement of a substring with itself

### DIFF
--- a/src/core/automator/index.ts
+++ b/src/core/automator/index.ts
@@ -7,7 +7,7 @@ import { format } from '@/utils/format';
 export function formatResult(result: any): string {
 	if (result instanceof Decimal) return format(result);
 	else if (typeof result == 'string') {
-		return `"${result.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+		return `"${result.replace(/\\/g, '\\\\')}"`;
 	} else if (Array.isArray(result)) {
 		return `[${result.map((x) => formatResult(x)).join(',')}]`;
 	} else if (result === undefined) return `No result`;

--- a/src/core/automator/index.ts
+++ b/src/core/automator/index.ts
@@ -7,7 +7,7 @@ import { format } from '@/utils/format';
 export function formatResult(result: any): string {
 	if (result instanceof Decimal) return format(result);
 	else if (typeof result == 'string') {
-		return `"${result.replace(/\\/g, '\\\\').replace(/"/g, '"')}"`;
+		return `"${result.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 	} else if (Array.isArray(result)) {
 		return `[${result.map((x) => formatResult(x)).join(',')}]`;
 	} else if (result === undefined) return `No result`;


### PR DESCRIPTION
Potential fix for [https://github.com/RBN-rewrite-team/RBNR/security/code-scanning/3](https://github.com/RBN-rewrite-team/RBNR/security/code-scanning/3)

To fix the issue, the code should replace any double quote (`"`) characters in the string with `\"` (backslash followed by double quote) instead of simply `"`. In JavaScript string literals, a backslash is written as `\\`, so the replacement string should be `'\\"'`. Update the `.replace(/"/g, '"')` to `.replace(/"/g, '\\"')` on line 10 in the file src/core/automator/index.ts. No new imports or additional method definitions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
